### PR TITLE
feat: basic float support

### DIFF
--- a/patch_test.go
+++ b/patch_test.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bxcodec/faker/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/bxcodec/faker/v3"
 	jsonpatch2 "github.com/evanphx/json-patch"
 
 	"github.com/snorwin/jsonpatch"
@@ -33,6 +33,7 @@ type B struct {
 	Uint32  uint32  `json:"uint32"`
 	Uint64  uint64  `json:"uint64"`
 	UintPtr uintptr `json:"ptr" faker:"-"`
+	Float64 float64 `json:"float64"`
 }
 
 type C struct {

--- a/walker.go
+++ b/walker.go
@@ -60,6 +60,10 @@ func (w *walker) walk(modified, current reflect.Value, pointer JSONPointer) erro
 		if modified.Bool() != current.Bool() {
 			w.replace(pointer, modified.Bool(), current.Bool())
 		}
+	case reflect.Float64:
+		if modified.Float() != current.Float() {
+			w.replace(pointer, modified.Float(), current.Float())
+		}
 	case reflect.Invalid:
 		// undefined interfaces are ignored for now
 		return nil


### PR DESCRIPTION
Add basic float support, but limited to float64 as float32 [has](https://github.com/golang/go/issues/34559) [issues](https://stackoverflow.com/questions/58566282/unmarshal-json-to-float-why-is-float64-required) with json.

Fixes https://github.com/snorwin/jsonpatch/issues/13, fixes https://github.com/snorwin/jsonpatch/pull/14

